### PR TITLE
Add NEEDS on patches

### DIFF
--- a/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
+++ b/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleCommand]]:Final
+@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[MechJeb2]:Final
 {
 	%MODULE[MechJebCore]
 	{
@@ -32,7 +32,7 @@
 //	}
 //}
 
-@PART[*]:HAS[@MODULE[ModuleCommand]]:Final
+@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[KerbalEngineer]:Final
 {
 	MODULE
 	{


### PR DESCRIPTION
Prevents KSP from complaining about nonexistent modules if you have one installed but not the other.