### PR TITLE
Improved kOS patch

### DIFF
--- a/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
+++ b/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[kOS]:Final
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[kOSProcessor]]:NEEDS[kOS]:Final
 {
 	MODULE
 	{

--- a/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
+++ b/GameData/MechJebForAll/MechJebAndEngineerForAll.cfg
@@ -45,6 +45,6 @@
 	MODULE
 	{
 		name = kOSProcessor
-		diskSpace = 10000000
+		diskSpace = 8000
 	}
 }

--- a/MechJebForAll.version
+++ b/MechJebForAll.version
@@ -8,9 +8,9 @@
   },
   "VERSION": {
     "MAJOR": 1,
-    "MINOR": 3,
+    "MINOR": 4,
     "PATCH": 0,
-    "BUILD": 6
+    "BUILD": 0
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,


### PR DESCRIPTION
This prevents kOSForAll to install CPUs on parts which already have them and reduces the ridiculous size.

For reference, many USI parts have 1k-5k storage, the huge WBI DSEV parts have 10k-16k so I chose something roughly in the middle.